### PR TITLE
Add ability to create PartWithFileContent from array of bytes.

### DIFF
--- a/src/main/java/coresearch/cvurl/io/multipart/MultipartBody.java
+++ b/src/main/java/coresearch/cvurl/io/multipart/MultipartBody.java
@@ -2,10 +2,7 @@ package coresearch.cvurl.io.multipart;
 
 import coresearch.cvurl.io.constant.HttpHeader;
 import coresearch.cvurl.io.constant.MultipartType;
-import coresearch.cvurl.io.exception.MultipartFileFormException;
 
-import java.io.IOException;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -127,8 +124,7 @@ public class MultipartBody {
     }
 
     /**
-     * Add a file form data part to the body with provided part name.Use name of provided file as value for filename field
-     * If Content-type is not previously set detect content-type from file.
+     * Add a file form data part to the body with provided part name.
      *
      * @param name part name
      * @param part part to add
@@ -138,34 +134,7 @@ public class MultipartBody {
         notNullParam(name, "name");
         notNullParam(part, "part");
 
-        return formPart(name, part.getFilePath().getFileName().toString(), part);
-    }
-
-    /**
-     * Add a file form data part to the body with provided part name.Use provided filename as value for filename field
-     * If Content-type is not previously set detect content-type from file.
-     *
-     * @param name part name
-     * @param filename value of filename field
-     * @param part part to add
-     * @return this {@link MultipartBody}
-     */
-    public MultipartBody formPart(String name, String filename, PartWithFileContent part) {
-        notNullParam(name, "name");
-        notNullParam(filename, "filename");
-        notNullParam(part, "part");
-
-        var path = part.getFilePath();
-        part.header(HttpHeader.CONTENT_DISPOSITION, getContentDispositionHeader(name, filename));
-
-        if (!part.isContentTypeSet()) {
-            try {
-                part.contentType(Files.probeContentType(path));
-            } catch (IOException e) {
-                throw new MultipartFileFormException(e.getMessage(), e.getCause());
-            }
-        }
-
+        part.header(HttpHeader.CONTENT_DISPOSITION, getContentDispositionHeader(name, part.getFileName()));
         this.parts.add(part);
         return this;
     }
@@ -178,4 +147,3 @@ public class MultipartBody {
         return String.format(CONTENT_DISPOSITION_WITH_FILENAME_TEMPLATE, name, filename);
     }
 }
-

--- a/src/main/java/coresearch/cvurl/io/multipart/Part.java
+++ b/src/main/java/coresearch/cvurl/io/multipart/Part.java
@@ -32,6 +32,7 @@ public class Part<T extends Part<T>> {
 
     /**
      * Creates new instance of {@link Part}
+     *
      * @param content content part
      * @return this {@link Part}
      */
@@ -43,6 +44,7 @@ public class Part<T extends Part<T>> {
 
     /**
      * Creates new instance of {@link Part}
+     *
      * @param content content part
      * @return this {@link Part}
      */
@@ -56,17 +58,45 @@ public class Part<T extends Part<T>> {
      * Creates new instance of {@link Part} using file from provided filePath
      * Throws {@link MultipartFileFormException} in case {@link IOException} happens
      * while reading from the file.
+     *
      * @param filePath path to file that will be used as content.
      * @return this {@link Part}
      */
     public static PartWithFileContent of(Path filePath) {
+        return of(filePath.getFileName().toString(), filePath);
+    }
+
+    /**
+     * Creates new instance of {@link Part} using file from provided filePath and filename
+     * Throws {@link MultipartFileFormException} in case {@link IOException} happens
+     * while reading from the file.
+     *
+     * @param filePath path to file that will be used as content.
+     * @return this {@link Part}
+     */
+    public static PartWithFileContent of(String fileName, Path filePath) {
+        notNullParam(fileName, "fileName");
         notNullParam(filePath, "filePath");
 
         try {
-            return new PartWithFileContent(filePath, Files.readAllBytes(filePath));
+            return new PartWithFileContent(fileName, Files.readAllBytes(filePath))
+                    .contentType(Files.probeContentType(filePath));
         } catch (IOException e) {
             throw new MultipartFileFormException(e.getMessage(), e);
         }
+    }
+
+    /**
+     * Creates new instance of {@link Part} using provided fileName, content and content type.
+     *
+     * @return this {@link Part}
+     */
+    public static PartWithFileContent of(String fileName, String contentType, byte[] content) {
+        notNullParam(fileName, "filePath");
+        notNullParam(contentType, "contentType");
+        notNullParam(content, "content");
+
+        return new PartWithFileContent(fileName, content).contentType(contentType);
     }
 
     /**

--- a/src/main/java/coresearch/cvurl/io/multipart/PartWithFileContent.java
+++ b/src/main/java/coresearch/cvurl/io/multipart/PartWithFileContent.java
@@ -1,24 +1,22 @@
 package coresearch.cvurl.io.multipart;
 
-import java.nio.file.Path;
-
 /**
  * Represent part with file content of multipart data.
  */
 public class PartWithFileContent extends Part<PartWithFileContent> {
-    private Path filePath;
+    private String fileName;
 
-    PartWithFileContent(Path filePath, byte[] content) {
+    PartWithFileContent(String fileName, byte[] content) {
         super(content);
-        this.filePath = filePath;
+        this.fileName = fileName;
     }
 
     /**
-     * Returns file path.
+     * Returns file name.
      *
-     * @return file path.
+     * @return file name.
      */
-    public Path getFilePath() {
-        return filePath;
+    public String getFileName() {
+        return fileName;
     }
 }

--- a/src/test/java/coresearch/cvurl/io/multipart/MultipartBodyTest.java
+++ b/src/test/java/coresearch/cvurl/io/multipart/MultipartBodyTest.java
@@ -136,7 +136,28 @@ public class MultipartBodyTest {
                         HttpHeader.CONTENT_TYPE, JSON_MIME_TYPE)));
 
         //when
-        MultipartBody multipartBody = MultipartBody.create(BOUNDARY).formPart(partName, filename, Part.of(jsonPath));
+        MultipartBody multipartBody = MultipartBody.create(BOUNDARY)
+                .formPart(partName, Part.of(filename, jsonPath));
+
+        //then
+        assertEquals(expectedResult, convertToString(multipartBody));
+    }
+
+    @Test
+    public void fileFormPartByteArrayTest() throws IOException {
+        //given
+        var partName = "name";
+        Path jsonPath = Resources.get(MULTIPART_BODY_TEST_JSON);
+        var filename = "filename";
+        var expectedResult = generateMultipartBody(BOUNDARY,
+                new TestPart(Files.readString(jsonPath), Map.of(
+                        HttpHeader.CONTENT_DISPOSITION, format(CONTENT_DISPOSITION_WITH_FILENAME_TEMPLATE,
+                                partName, filename),
+                        HttpHeader.CONTENT_TYPE, JSON_MIME_TYPE)));
+
+        //when
+        MultipartBody multipartBody = MultipartBody.create(BOUNDARY)
+                .formPart(partName, Part.of(filename, JSON_MIME_TYPE, Files.readAllBytes(jsonPath)));
 
         //then
         assertEquals(expectedResult, convertToString(multipartBody));


### PR DESCRIPTION
As I was writing example for CVurl usage I realized that we need to add ability to build multipart/form-data part with file content not only from the Path but also from simple array of bytes. It's because we don't always have file system representation of the file that we want to send, maybe it's bytes of file that we got from somebody who uses our rest api or file that we got from another api that we don't want to save to hard drive.