### PR TITLE
Fix RequestWithBodyBuilder#formData.

### DIFF
--- a/src/main/java/coresearch/cvurl/io/request/RequestWithBodyBuilder.java
+++ b/src/main/java/coresearch/cvurl/io/request/RequestWithBodyBuilder.java
@@ -80,7 +80,7 @@ public class RequestWithBodyBuilder extends RequestBuilder<RequestWithBodyBuilde
      * @param body request body
      * @return this builder
      */
-    public RequestWithBodyBuilder formData(Map<Object, Object> body) {
+    public RequestWithBodyBuilder formData(Map<?, ?> body) {
         if (body.isEmpty()) {
             throw new IllegalStateException("Form data map shouldn't be empty");
         }

--- a/src/test/java/coresearch/cvurl/io/request/CVurlRequestTest.java
+++ b/src/test/java/coresearch/cvurl/io/request/CVurlRequestTest.java
@@ -413,7 +413,7 @@ public class CVurlRequestTest extends AbstractRequestTest {
         var value1 = "value1";
         var value2 = "value2";
         var expectedBody = paramName1 + "=" + value1 + "&" + paramName2 + "=" + value2;
-        var paramsMap = new LinkedHashMap<>() {{
+        Map<String, String> paramsMap = new LinkedHashMap<>() {{
             put(paramName1, value1);
             put(paramName2, value2);
         }};


### PR DESCRIPTION
Fix RequestWithBodyBuilder#formData to accept reference to Map parametrized by any type, not only Object.