### PR TITLE
Java 13 compatibility.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: java
 jdk:
   - oraclejdk11
-  - oraclejdk12
+  - oraclejdk13
   - openjdk11
-  - openjdk12
+  - openjdk13
 
 after_success:
   - |

--- a/src/test/java/coresearch/cvurl/io/model/ConfigurationTest.java
+++ b/src/test/java/coresearch/cvurl/io/model/ConfigurationTest.java
@@ -2,36 +2,37 @@ package coresearch.cvurl.io.model;
 
 import coresearch.cvurl.io.constant.HttpClientMode;
 import coresearch.cvurl.io.internal.configuration.RequestConfiguration;
-import coresearch.cvurl.io.mapper.GenericMapper;
+import coresearch.cvurl.io.mapper.MapperFactory;
 import coresearch.cvurl.io.mapper.impl.JacksonMapper;
+import coresearch.cvurl.io.utils.MockHttpClient;
+import coresearch.cvurl.io.utils.MockProxySelector;
 import org.junit.jupiter.api.Test;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLParameters;
 import java.net.Authenticator;
-import java.net.CookieHandler;
-import java.net.ProxySelector;
+import java.net.CookieManager;
 import java.net.http.HttpClient;
+import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Optional;
-import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.mock;
 
 public class ConfigurationTest {
 
     @Test
-    public void builderTest() {
+    public void builderTest() throws NoSuchAlgorithmException {
         //given
-        var authenticator = mock(Authenticator.class);
+        var authenticator = new Authenticator() {};
         var connectTimeout = Duration.ofSeconds(1);
-        var cookieHandler = mock(CookieHandler.class);
-        var executor = mock(Executor.class);
-        var followRedirects = mock(HttpClient.Redirect.class);
-        var proxySelector = mock(ProxySelector.class);
-        var sslContext = mock(SSLContext.class);
+        var cookieHandler = new CookieManager();
+        var executor = Executors.newFixedThreadPool(1);
+        var followRedirects = HttpClient.Redirect.NEVER;
+        var proxySelector = MockProxySelector.create();
+        var sslContext = SSLContext.getDefault();
         var sslParameters = new SSLParameters(new String[]{"test"});
         var priority = 1;
         var version = HttpClient.Version.HTTP_1_1;
@@ -63,15 +64,15 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void createHttpClientTest() {
+    public void createHttpClientTest() throws NoSuchAlgorithmException {
         //given
-        var authenticator = mock(Authenticator.class);
+        var authenticator = new Authenticator() {};
         var connectTimeout = Duration.ofSeconds(1);
-        var cookieHandler = mock(CookieHandler.class);
-        var executor = mock(Executor.class);
-        var followRedirects = mock(HttpClient.Redirect.class);
-        var proxySelector = mock(ProxySelector.class);
-        var sslContext = mock(SSLContext.class);
+        var cookieHandler = new CookieManager();
+        var executor = Executors.newFixedThreadPool(1);
+        var followRedirects = HttpClient.Redirect.NEVER;
+        var proxySelector = MockProxySelector.create();
+        var sslContext = SSLContext.getDefault();
         var sslParameters = new SSLParameters(new String[]{"test"});
         var priority = 1;
         var version = HttpClient.Version.HTTP_1_1;
@@ -106,9 +107,9 @@ public class ConfigurationTest {
     @Test
     public void httpClientBasedBuilderTest() {
         //given
-        var httpClient = mock(HttpClient.class);
-        var genericMapper = mock(GenericMapper.class);
-        var requestTimeout = mock(Duration.class);
+        var httpClient = MockHttpClient.create();
+        var genericMapper = MapperFactory.createDefault();
+        var requestTimeout = Duration.ofSeconds(42);
         var acceptCompressed = true;
 
         //when
@@ -172,8 +173,8 @@ public class ConfigurationTest {
     @Test
     public void configurationBuilderTest() {
         //given
-        var httpClient = mock(HttpClient.class);
-        var genericMapper = mock(GenericMapper.class);
+        var httpClient = MockHttpClient.create();
+        var genericMapper = MapperFactory.createDefault();
         var clientMode = HttpClientMode.PROTOTYPE;
         var timeout = Duration.ofSeconds(1);
         var acceptCompressed = true;

--- a/src/test/java/coresearch/cvurl/io/model/ResponseTest.java
+++ b/src/test/java/coresearch/cvurl/io/model/ResponseTest.java
@@ -1,36 +1,32 @@
 package coresearch.cvurl.io.model;
 
-import name.falgout.jeffrey.testing.junit.mockito.MockitoExtension;
+import coresearch.cvurl.io.utils.MockHttpRequest;
+import coresearch.cvurl.io.utils.MockHttpResponse;
+import coresearch.cvurl.io.utils.MockSSLSession;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 
 import javax.net.ssl.SSLSession;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.net.http.HttpHeaders;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
-@ExtendWith(MockitoExtension.class)
 public class ResponseTest {
 
-    @Mock
-    public HttpResponse<String> httpResponse;
+    public MockHttpResponse httpResponse = MockHttpResponse.create();
 
     @Test
     public void requestTest() {
         //given
-        HttpRequest request = mock(HttpRequest.class);
-        when(httpResponse.request()).thenReturn(request);
+        HttpRequest request = MockHttpRequest.create();
+        httpResponse.setHttpRequest(request);
 
         //when
         HttpRequest result = new Response<>(httpResponse).request();
@@ -42,8 +38,8 @@ public class ResponseTest {
     @Test
     public void previousResponseTest() {
         //given
-        HttpResponse<String> previousResponse = mock(HttpResponse.class);
-        when(httpResponse.previousResponse()).thenReturn(Optional.of(previousResponse));
+        HttpResponse<String> previousResponse = MockHttpResponse.create();
+        httpResponse.setPreviousResponse(previousResponse);
 
         //when
         HttpResponse<String> result = new Response<>(httpResponse).previousResponse().orElseThrow(RuntimeException::new);
@@ -55,8 +51,8 @@ public class ResponseTest {
     @Test
     public void sslSessionTest() {
         //given
-        SSLSession sslSession = mock(SSLSession.class);
-        when(httpResponse.sslSession()).thenReturn(Optional.of(sslSession));
+        SSLSession sslSession = MockSSLSession.create();
+        httpResponse.setSslSession(sslSession);
 
         //when
         SSLSession result = new Response<>(httpResponse).sslSession().orElseThrow(RuntimeException::new);
@@ -66,10 +62,10 @@ public class ResponseTest {
     }
 
     @Test
-    public void uriTest() {
+    public void uriTest() throws URISyntaxException {
         //given
-        URI uri = mock(URI.class);
-        when(httpResponse.uri()).thenReturn(uri);
+        URI uri = new URI("//https://www.google.com/");
+        httpResponse.setUri(uri);
 
         //when
         URI result = new Response<>(httpResponse).uri();
@@ -81,9 +77,8 @@ public class ResponseTest {
     @Test
     public void versionTest() {
         //given
-        HttpClient.Version version = mock(HttpClient.Version.class);
-        when(httpResponse.version()).thenReturn(version);
-
+        HttpClient.Version version = HttpClient.Version.HTTP_1_1;
+        httpResponse.setVersion(version);
         //when
         HttpClient.Version result = new Response<>(httpResponse).version();
 
@@ -97,7 +92,7 @@ public class ResponseTest {
         String key = "key";
         List<String> values = List.of("val1", "val2");
         HttpHeaders headers = HttpHeaders.of(Map.of(key, values), (k, v) -> true);
-        when(httpResponse.headers()).thenReturn(headers);
+        httpResponse.setHeaders(headers);
 
         //when
         List<String> result = new Response<>(httpResponse).getHeaderValuesAsList(key);

--- a/src/test/java/coresearch/cvurl/io/utils/MockHttpClient.java
+++ b/src/test/java/coresearch/cvurl/io/utils/MockHttpClient.java
@@ -1,0 +1,89 @@
+package coresearch.cvurl.io.utils;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+import java.io.IOException;
+import java.net.Authenticator;
+import java.net.CookieHandler;
+import java.net.ProxySelector;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+public class MockHttpClient extends HttpClient {
+
+    public List<HttpRequest> requests = new ArrayList<>();
+
+    private MockHttpClient() { }
+
+    public static MockHttpClient create() {
+        return new MockHttpClient();
+    }
+
+    @Override
+    public Optional<CookieHandler> cookieHandler() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Duration> connectTimeout() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Redirect followRedirects() {
+        return null;
+    }
+
+    @Override
+    public Optional<ProxySelector> proxy() {
+        return Optional.empty();
+    }
+
+    @Override
+    public SSLContext sslContext() {
+        return null;
+    }
+
+    @Override
+    public SSLParameters sslParameters() {
+        return null;
+    }
+
+    @Override
+    public Optional<Authenticator> authenticator() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Version version() {
+        return null;
+    }
+
+    @Override
+    public Optional<Executor> executor() {
+        return Optional.empty();
+    }
+
+    @Override
+    public <T> HttpResponse<T> send(HttpRequest request, HttpResponse.BodyHandler<T> responseBodyHandler) throws IOException, InterruptedException {
+        requests.add(request);
+        return null;
+    }
+
+    @Override
+    public <T> CompletableFuture<HttpResponse<T>> sendAsync(HttpRequest request, HttpResponse.BodyHandler<T> responseBodyHandler) {
+        return null;
+    }
+
+    @Override
+    public <T> CompletableFuture<HttpResponse<T>> sendAsync(HttpRequest request, HttpResponse.BodyHandler<T> responseBodyHandler, HttpResponse.PushPromiseHandler<T> pushPromiseHandler) {
+        return null;
+    }
+}

--- a/src/test/java/coresearch/cvurl/io/utils/MockHttpRequest.java
+++ b/src/test/java/coresearch/cvurl/io/utils/MockHttpRequest.java
@@ -1,0 +1,53 @@
+package coresearch.cvurl.io.utils;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.time.Duration;
+import java.util.Optional;
+
+public class MockHttpRequest extends HttpRequest {
+
+    private MockHttpRequest() {
+    }
+
+    public static MockHttpRequest create() {
+        return new MockHttpRequest();
+    }
+
+    @Override
+    public Optional<BodyPublisher> bodyPublisher() {
+        return Optional.empty();
+    }
+
+    @Override
+    public String method() {
+        return null;
+    }
+
+    @Override
+    public Optional<Duration> timeout() {
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean expectContinue() {
+        return false;
+    }
+
+    @Override
+    public URI uri() {
+        return null;
+    }
+
+    @Override
+    public Optional<HttpClient.Version> version() {
+        return Optional.empty();
+    }
+
+    @Override
+    public HttpHeaders headers() {
+        return null;
+    }
+}

--- a/src/test/java/coresearch/cvurl/io/utils/MockHttpResponse.java
+++ b/src/test/java/coresearch/cvurl/io/utils/MockHttpResponse.java
@@ -1,0 +1,94 @@
+package coresearch.cvurl.io.utils;
+
+import javax.net.ssl.SSLSession;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Optional;
+
+public class MockHttpResponse implements HttpResponse<String> {
+
+    private URI uri;
+    private HttpHeaders headers;
+    private HttpRequest httpRequest;
+    private HttpResponse<String> previousResponse;
+    private SSLSession sslSession;
+    private String body;
+    private HttpClient.Version version;
+
+    private MockHttpResponse() { }
+
+    public static MockHttpResponse create() {
+        return new MockHttpResponse();
+    }
+
+    @Override
+    public int statusCode() {
+        return 0;
+    }
+
+    @Override
+    public HttpRequest request() {
+        return httpRequest;
+    }
+
+    @Override
+    public Optional<HttpResponse<String>> previousResponse() {
+        return Optional.ofNullable(previousResponse);
+    }
+
+    @Override
+    public HttpHeaders headers() {
+        return headers;
+    }
+
+    @Override
+    public String body() {
+        return body;
+    }
+
+    @Override
+    public Optional<SSLSession> sslSession() {
+        return Optional.ofNullable(sslSession);
+    }
+
+    @Override
+    public URI uri() {
+        return uri;
+    }
+
+    @Override
+    public HttpClient.Version version() {
+        return version;
+    }
+
+    public void setUri(URI uri) {
+        this.uri = uri;
+    }
+
+    public void setHeaders(HttpHeaders headers) {
+        this.headers = headers;
+    }
+
+    public void setHttpRequest(HttpRequest httpRequest) {
+        this.httpRequest = httpRequest;
+    }
+
+    public void setPreviousResponse(HttpResponse<String> previousResponse) {
+        this.previousResponse = previousResponse;
+    }
+
+    public void setSslSession(SSLSession sslSession) {
+        this.sslSession = sslSession;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    public void setVersion(HttpClient.Version version) {
+        this.version = version;
+    }
+}

--- a/src/test/java/coresearch/cvurl/io/utils/MockProxySelector.java
+++ b/src/test/java/coresearch/cvurl/io/utils/MockProxySelector.java
@@ -1,0 +1,28 @@
+package coresearch.cvurl.io.utils;
+
+import java.io.IOException;
+import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.SocketAddress;
+import java.net.URI;
+import java.util.List;
+
+public class MockProxySelector extends ProxySelector {
+
+    private MockProxySelector() {
+    }
+
+    public static MockProxySelector create(){
+        return new MockProxySelector();
+    }
+
+    @Override
+    public List<Proxy> select(URI uri) {
+        return null;
+    }
+
+    @Override
+    public void connectFailed(URI uri, SocketAddress sa, IOException ioe) {
+
+    }
+}

--- a/src/test/java/coresearch/cvurl/io/utils/MockSSLSession.java
+++ b/src/test/java/coresearch/cvurl/io/utils/MockSSLSession.java
@@ -1,0 +1,125 @@
+package coresearch.cvurl.io.utils;
+
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSessionContext;
+import javax.security.cert.X509Certificate;
+import java.security.Principal;
+import java.security.cert.Certificate;
+
+public class MockSSLSession implements SSLSession {
+
+    private MockSSLSession() {
+    }
+
+    public static MockSSLSession create() {
+        return new MockSSLSession();
+    }
+
+    ;
+
+    @Override
+    public byte[] getId() {
+        return new byte[0];
+    }
+
+    @Override
+    public SSLSessionContext getSessionContext() {
+        return null;
+    }
+
+    @Override
+    public long getCreationTime() {
+        return 0;
+    }
+
+    @Override
+    public long getLastAccessedTime() {
+        return 0;
+    }
+
+    @Override
+    public void invalidate() {
+
+    }
+
+    @Override
+    public boolean isValid() {
+        return false;
+    }
+
+    @Override
+    public void putValue(String s, Object o) {
+
+    }
+
+    @Override
+    public Object getValue(String s) {
+        return null;
+    }
+
+    @Override
+    public void removeValue(String s) {
+
+    }
+
+    @Override
+    public String[] getValueNames() {
+        return new String[0];
+    }
+
+    @Override
+    public Certificate[] getPeerCertificates() throws SSLPeerUnverifiedException {
+        return new Certificate[0];
+    }
+
+    @Override
+    public Certificate[] getLocalCertificates() {
+        return new Certificate[0];
+    }
+
+    @Override
+    public X509Certificate[] getPeerCertificateChain() throws SSLPeerUnverifiedException {
+        return new X509Certificate[0];
+    }
+
+    @Override
+    public Principal getPeerPrincipal() throws SSLPeerUnverifiedException {
+        return null;
+    }
+
+    @Override
+    public Principal getLocalPrincipal() {
+        return null;
+    }
+
+    @Override
+    public String getCipherSuite() {
+        return null;
+    }
+
+    @Override
+    public String getProtocol() {
+        return null;
+    }
+
+    @Override
+    public String getPeerHost() {
+        return null;
+    }
+
+    @Override
+    public int getPeerPort() {
+        return 0;
+    }
+
+    @Override
+    public int getPacketBufferSize() {
+        return 0;
+    }
+
+    @Override
+    public int getApplicationBufferSize() {
+        return 0;
+    }
+}


### PR DESCRIPTION
The latest version of mockito (3.1.0) doesn't support mocking Java 13 classes.

Add custom mocks for classes from java.net.